### PR TITLE
Add REQUIRES esp_timer to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(
 	SRCS "TinyGPSPlus/src/TinyGPS++.cpp"
-    INCLUDE_DIRS "TinyGPSPlus/src" "include")
+    INCLUDE_DIRS "TinyGPSPlus/src" "include"
+    REQUIRES "esp_timer")


### PR DESCRIPTION
When building a test repo with just TinyGPSPlus-ESPIDF as a component (here I cloned as tinygpsplus), I get the following error:
```
In file included from /workspaces/repos/test/components/tinygpsplus/TinyGPSPlus/src/TinyGPS++.h:30,
                 from /workspaces/repos/test/components/tinygpsplus/TinyGPSPlus/src/TinyGPS++.cpp:24:
/workspaces/repos/test/components/tinygpsplus/include/WProgram.h:26:10: fatal error: esp_timer.h: No such file or directory
   26 | #include "esp_timer.h"
      |          ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [esp-idf/tinygpsplus/CMakeFiles/__idf_tinygpsplus.dir/build.make:76: esp-idf/tinygpsplus/CMakeFiles/__idf_tinygpsplus.dir/TinyGPSPlus/src/TinyGPS++.cpp.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:5915: esp-idf/tinygpsplus/CMakeFiles/__idf_tinygpsplus.dir/all] Error 2
```
Adding "REQUIRES esp_timer" resolved this issue.
It seems like version 5+ of ESP-IDF requires that some dependencies must be explicitly REQUIRED. https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32s2/migration-guides/release-5.x/build-system.html#specify-component-requirements-explicitly